### PR TITLE
Add functions raw ADC data, Volt converted, DRDY non blocking

### DIFF
--- a/ADS1256.h
+++ b/ADS1256.h
@@ -141,12 +141,14 @@ class ADS1256 {
   void writeRegister(unsigned char reg, unsigned char wdata);
   unsigned char readRegister(unsigned char reg);
   void sendCommand(unsigned char cmd);
+  float readCurrentChannelVolt();
   float readCurrentChannel();
   void setConversionFactor(float val);
   void setChannel(byte channel);
   void setChannel(byte AIP, byte AIN);
   void begin(unsigned char drate, unsigned char gain, bool bufferenable);
   void waitDRDY();
+  boolean isDRDY();	
   void setGain(uint8_t gain);
   void readTest();
 


### PR DESCRIPTION
Added readCurrentChannelVolt(); returns volts units (previous behaviour of readCurrentChannel() )
Changed readCurrentChannel(); previously returned volts units, now it returns raw ADC value
Added isDRDY(); a non blocking function (contrary to waitDRDY(); that is blocking) to check if ADC cycle is completed and data is ready to be read